### PR TITLE
DeviceConnectCodegen 1.8.2

### DIFF
--- a/DeviceConnectCodegen/README.md
+++ b/DeviceConnectCodegen/README.md
@@ -33,7 +33,7 @@ DeviceConnect Codegenは、DeviceConnectシステム上で動作するプラグ�
 |samples/profiles-specs|シェルスクリプトのサンプルに入力するプロファイル定義ファイル群。|
 
 ## Get Started
-[deviceconnect-codegen-project-1.7.0-dist.zip](https://github.com/TakayukiHoshi1984/DeviceConnect-Experiments/releases/tag/codegen-v1.7.0) をPC上の任意の場所にダウンロードし、解凍してください。
+[deviceconnect-codegen-project-1.8.2-dist.zip](https://github.com/TakayukiHoshi1984/DeviceConnect-Experiments/releases/tag/codegen-v1.8.2) をPC上の任意の場所にダウンロードし、解凍してください。
 
 解凍後、ターミナルを起動し、以下のコマンドによりをサンプルのスケルトンコードを生成してください。
 

--- a/DeviceConnectCodegen/RELEASENOTE.TXT
+++ b/DeviceConnectCodegen/RELEASENOTE.TXT
@@ -1,4 +1,11 @@
 # 変更履歴
+2018/12/10: v1.8.2 [共通] swagger-codegen v2.2.3 を使用するように変更。v2.2.1 に関する脆弱性への対処のため。
+                   [Markdown] 不具合修正: GitHub Wikiにアップロードすると各API仕様へのタグジャンプが行えない。
+
+2018/09/27: v1.8.1 [NodeJS] メンテナンス: NodeJS向けに出力するデバイスプラグインのREADMEにServiceInformationを追加
+
+2018/09/12: v1.8.0 [NodeJS] NodeJS向けに出力するデバイスプラグインのソースコードを改善
+
 2018/03/01: v1.6.0 [Android] オプション追加: --gradle-plugin-version, --sdk, --signing-config, --template-dir
                    [共通] 不具合修正: basePathプロパティでプロファイル名が定義されている場合に異常終了
 

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/pom.xml
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-codegen</artifactId>
-            <version>2.2.1</version>
+            <version>2.2.2</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/pom.xml
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.deviceconnect</groupId>
     <artifactId>deviceconnect-codegen</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
 
     <packaging>jar</packaging>
 

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/pom.xml
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>io.swagger</groupId>
             <artifactId>swagger-codegen</artifactId>
-            <version>2.2.2</version>
+            <version>2.2.3</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/AbstractCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/AbstractCodegenConfig.java
@@ -22,6 +22,8 @@ import java.util.regex.Pattern;
 
 public abstract class AbstractCodegenConfig extends DefaultCodegen implements DConnectCodegenConfig {
 
+    protected Swagger originalSwagger;
+
     protected Map<String, Swagger> profileSpecs;
 
     protected abstract String profileFileFolder();
@@ -39,6 +41,16 @@ public abstract class AbstractCodegenConfig extends DefaultCodegen implements DC
     @Override
     public void setProfileSpecs(final Map<String, Swagger> profileSpecs) {
         this.profileSpecs = profileSpecs;
+    }
+
+    @Override
+    public Swagger getOriginalSwagger() {
+        return this.originalSwagger;
+    }
+
+    @Override
+    public void setOriginalSwagger(final Swagger swagger) {
+        this.originalSwagger = swagger;
     }
 
     @Override

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/AbstractCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/AbstractCodegenConfig.java
@@ -58,6 +58,11 @@ public abstract class AbstractCodegenConfig extends DefaultCodegen implements DC
         return input.replace("*/", "*_/").replace("/*", "/_*");
     }
 
+    @Override
+    public String escapeQuotationMark(final String input) {
+        return input.replace("\"", "\\\"");
+    }
+
     protected static String toUpperCapital(final String str, final boolean onlyFirstChar) {
         StringBuffer buf = new StringBuffer(str.length());
         buf.append(str.substring(0, 1).toUpperCase());

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
@@ -23,6 +23,7 @@ import org.apache.commons.cli.*;
 import org.deviceconnect.codegen.app.HtmlAppCodegenConfig;
 import org.deviceconnect.codegen.docs.HtmlDocsCodegenConfig;
 import org.deviceconnect.codegen.docs.MarkdownDocsCodegenConfig;
+import org.deviceconnect.codegen.util.SortedSwagger;
 import org.deviceconnect.codegen.util.SwaggerJsonValidator;
 import org.deviceconnect.codegen.util.SwaggerUtils;
 import org.slf4j.Logger;
@@ -361,7 +362,7 @@ public class DConnectCodegen {
     }
 
     private static Swagger createProfileSpec(final Swagger swagger) {
-        Swagger profile = new Swagger();
+        Swagger profile = new SortedSwagger();
         profile.setSwagger(swagger.getSwagger());
         Info info = new Info();
         info.setTitle(swagger.getInfo().getTitle());
@@ -459,7 +460,7 @@ public class DConnectCodegen {
     }
 
     private static Swagger mergeSwaggers(Map<String, Swagger> swaggerMap) {
-        Swagger merged = new Swagger();
+        Swagger merged = new SortedSwagger();
         merged.setBasePath("/");
 
         // info

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
@@ -7,7 +7,6 @@
 package org.deviceconnect.codegen;
 
 
-import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -20,12 +19,12 @@ import io.swagger.models.Model;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
-import io.swagger.util.Json;
 import org.apache.commons.cli.*;
 import org.deviceconnect.codegen.app.HtmlAppCodegenConfig;
 import org.deviceconnect.codegen.docs.HtmlDocsCodegenConfig;
 import org.deviceconnect.codegen.docs.MarkdownDocsCodegenConfig;
 import org.deviceconnect.codegen.util.SwaggerJsonValidator;
+import org.deviceconnect.codegen.util.SwaggerUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -268,7 +267,7 @@ public class DConnectCodegen {
             profile.setPaths(subPaths);
         }
         config.setProfileSpecs(profiles);
-        config.setOriginalSwagger(cloneSwagger(swagger));
+        config.setOriginalSwagger(SwaggerUtils.cloneSwagger(swagger));
     }
 
     private static void parseSwaggerFromDirectory(File dir,
@@ -307,20 +306,8 @@ public class DConnectCodegen {
         }
         config.setProfileSpecs(profileSpecs);
         Swagger swagger = mergeSwaggers(profileSpecs);
-        config.setOriginalSwagger(cloneSwagger(swagger));
+        config.setOriginalSwagger(SwaggerUtils.cloneSwagger(swagger));
         clientOptInput.swagger(swagger);
-    }
-
-    protected static JsonNode convertToNode(final Swagger swagger) throws IOException {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
-        String jsonAsString = mapper.writeValueAsString(swagger);
-        return mapper.readTree(jsonAsString);
-    }
-
-    private static Swagger cloneSwagger(final Swagger swagger) throws IOException {
-        JsonNode json = convertToNode(swagger);
-        return Json.mapper().convertValue(json, Swagger.class);
     }
 
     private static boolean checkSwagger(final File file) throws IOException, ProcessingException {
@@ -480,6 +467,18 @@ public class DConnectCodegen {
         info.setTitle("Device Connect");
         info.setVersion("1.0.0");
         merged.setInfo(info);
+
+        // consumes
+        List<String> consumes = new ArrayList<>();
+        for (Map.Entry<String, Swagger> entry : swaggerMap.entrySet()) {
+            Swagger swagger = entry.getValue();
+            for (String mimeType : swagger.getConsumes()) {
+                if (!consumes.contains(mimeType)) {
+                    consumes.add(mimeType);
+                }
+            }
+        }
+        merged.setConsumes(consumes);
 
         // paths
         Map<String, Path> paths = new HashMap<>();

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
@@ -266,6 +266,7 @@ public class DConnectCodegen {
             profile.setPaths(subPaths);
         }
         config.setProfileSpecs(profiles);
+        config.setOriginalSwagger(swagger);
     }
 
     private static void parseSwaggerFromDirectory(File dir,
@@ -303,7 +304,9 @@ public class DConnectCodegen {
             checkProfileName(config, profileName);
         }
         config.setProfileSpecs(profileSpecs);
-        clientOptInput.swagger(mergeSwaggers(profileSpecs));
+        Swagger swagger = mergeSwaggers(profileSpecs);
+        config.setOriginalSwagger(swagger);
+        clientOptInput.swagger(swagger);
     }
 
     private static boolean checkSwagger(final File file) throws IOException, ProcessingException {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
@@ -469,16 +469,19 @@ public class DConnectCodegen {
         merged.setInfo(info);
 
         // consumes
-        List<String> consumes = new ArrayList<>();
+        List<String> allConsumes = new ArrayList<>();
         for (Map.Entry<String, Swagger> entry : swaggerMap.entrySet()) {
             Swagger swagger = entry.getValue();
-            for (String mimeType : swagger.getConsumes()) {
-                if (!consumes.contains(mimeType)) {
-                    consumes.add(mimeType);
+            List<String> consumes = swagger.getConsumes();
+            if (consumes != null) {
+                for (String mimeType : consumes) {
+                    if (!allConsumes.contains(mimeType)) {
+                        allConsumes.add(mimeType);
+                    }
                 }
             }
         }
-        merged.setConsumes(consumes);
+        merged.setConsumes(allConsumes);
 
         // paths
         Map<String, Path> paths = new HashMap<>();

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
@@ -203,9 +203,11 @@ public class DConnectCodegen {
             new Codegen() {
                 @Override
                 public File writeToFile(final String filename, final String contents) throws IOException {
-                    // LICENSE ファイルは出力させない
+                    // 不要なファイルは出力させない
                     if (filename != null) {
-                        if (filename.endsWith("LICENSE") || filename.endsWith(".swagger-codegen-ignore")) {
+                        if (filename.endsWith("VERSION")
+                            || filename.endsWith("LICENSE")
+                            || filename.endsWith(".swagger-codegen-ignore")) {
                             return null;
                         }
                     }

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegen.java
@@ -7,6 +7,7 @@
 package org.deviceconnect.codegen;
 
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
@@ -19,6 +20,7 @@ import io.swagger.models.Model;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
+import io.swagger.util.Json;
 import org.apache.commons.cli.*;
 import org.deviceconnect.codegen.app.HtmlAppCodegenConfig;
 import org.deviceconnect.codegen.docs.HtmlDocsCodegenConfig;
@@ -266,7 +268,7 @@ public class DConnectCodegen {
             profile.setPaths(subPaths);
         }
         config.setProfileSpecs(profiles);
-        config.setOriginalSwagger(swagger);
+        config.setOriginalSwagger(cloneSwagger(swagger));
     }
 
     private static void parseSwaggerFromDirectory(File dir,
@@ -305,8 +307,20 @@ public class DConnectCodegen {
         }
         config.setProfileSpecs(profileSpecs);
         Swagger swagger = mergeSwaggers(profileSpecs);
-        config.setOriginalSwagger(swagger);
+        config.setOriginalSwagger(cloneSwagger(swagger));
         clientOptInput.swagger(swagger);
+    }
+
+    protected static JsonNode convertToNode(final Swagger swagger) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        String jsonAsString = mapper.writeValueAsString(swagger);
+        return mapper.readTree(jsonAsString);
+    }
+
+    private static Swagger cloneSwagger(final Swagger swagger) throws IOException {
+        JsonNode json = convertToNode(swagger);
+        return Json.mapper().convertValue(json, Swagger.class);
     }
 
     private static boolean checkSwagger(final File file) throws IOException, ProcessingException {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegenConfig.java
@@ -12,7 +12,6 @@ import io.swagger.codegen.CodegenConfig;
 import io.swagger.models.Swagger;
 import org.apache.commons.cli.CommandLine;
 
-import java.io.File;
 import java.util.Map;
 
 public interface DConnectCodegenConfig extends CodegenConfig {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectCodegenConfig.java
@@ -21,6 +21,10 @@ public interface DConnectCodegenConfig extends CodegenConfig {
 
     void setProfileSpecs(Map<String, Swagger> profileSpecs);
 
+    Swagger getOriginalSwagger();
+
+    void setOriginalSwagger(Swagger swagger);
+
     String getDefaultDisplayName();
 
     ValidationResultSet validateOptions(CommandLine cmd, ClientOpts clientOpts);

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectPath.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/DConnectPath.java
@@ -144,4 +144,16 @@ public class DConnectPath {
     public String toString() {
         return getPath();
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (o == null) {
+            return false;
+        }
+        if (!(o instanceof DConnectPath)) {
+            return false;
+        }
+        DConnectPath that = (DConnectPath) o;
+        return that.pathExp.equalsIgnoreCase(this.pathExp);
+    }
 }

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/MultipleSwaggerConverter.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/MultipleSwaggerConverter.java
@@ -11,6 +11,7 @@ import io.swagger.models.Info;
 import io.swagger.models.Model;
 import io.swagger.models.Path;
 import io.swagger.models.Swagger;
+import org.deviceconnect.codegen.util.SortedSwagger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,7 +88,7 @@ class MultipleSwaggerConverter {
     }
 
     private static Swagger createProfileSpec(final Swagger swagger) {
-        Swagger profile = new Swagger();
+        Swagger profile = new SortedSwagger();
         profile.setSwagger(swagger.getSwagger());
         Info info = new Info();
         info.setTitle(swagger.getInfo().getTitle());

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/MultipleSwaggerConverter.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/MultipleSwaggerConverter.java
@@ -52,7 +52,7 @@ class MultipleSwaggerConverter {
             String pathName = entry.getKey();
             DConnectPath path = DConnectPath.parsePath(basePath, pathName);
             counter.count(path.toCanonicalPathName());
-            LOGGER.info("Base Path: " + path.getBathPath() + ", Sub Path: " + path.getSubPath() + ", Profile: " + path.getProfileName());
+            LOGGER.debug("Base Path: " + path.getBathPath() + ", Sub Path: " + path.getSubPath() + ", Profile: " + path.getProfileName());
 
             String key = path.getProfileName();
             Swagger cache = result.get(key);

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/app/HtmlAppCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/app/HtmlAppCodegenConfig.java
@@ -17,14 +17,20 @@ import io.swagger.codegen.SupportingFile;
 import io.swagger.models.Swagger;
 import io.swagger.parser.SwaggerParser;
 import org.apache.commons.cli.CommandLine;
+import org.deviceconnect.codegen.AbstractCodegenConfig;
 import org.deviceconnect.codegen.DConnectCodegenConfig;
 import org.deviceconnect.codegen.ValidationResultSet;
 
 import java.util.Map;
 
-public class HtmlAppCodegenConfig extends DefaultCodegen implements DConnectCodegenConfig {
+public class HtmlAppCodegenConfig extends AbstractCodegenConfig implements DConnectCodegenConfig {
 
     private Map<String, Swagger> profileSpecs;
+
+    @Override
+    protected String profileFileFolder() {
+        return null; // Not be used.
+    }
 
     @Override
     public ValidationResultSet validateOptions(final CommandLine cmd, final ClientOpts clientOpts) {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/app/HtmlAppCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/app/HtmlAppCodegenConfig.java
@@ -15,7 +15,6 @@ import io.swagger.codegen.CodegenType;
 import io.swagger.codegen.DefaultCodegen;
 import io.swagger.codegen.SupportingFile;
 import io.swagger.models.Swagger;
-import io.swagger.parser.SwaggerParser;
 import org.apache.commons.cli.CommandLine;
 import org.deviceconnect.codegen.AbstractCodegenConfig;
 import org.deviceconnect.codegen.DConnectCodegenConfig;

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/docs/AbstractDocsCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/docs/AbstractDocsCodegenConfig.java
@@ -68,7 +68,6 @@ public abstract class AbstractDocsCodegenConfig extends AbstractCodegenConfig {
                 basePath = "/gotapi/" + profileKey;
                 profileName = profileKey;
             } else {
-                System.out.println("basePath: " + basePath);
                 profileName = basePath.split("/")[2];
             }
 

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/docs/AbstractDocsCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/docs/AbstractDocsCodegenConfig.java
@@ -149,6 +149,13 @@ public abstract class AbstractDocsCodegenConfig extends AbstractCodegenConfig {
                         }
                         Object response = createResponseDocument(profileSpec, op);
                         Object event = createEventDocument(profileSpec, op);
+                        String tag() {
+                            String tag = this.name;
+                            tag = tag.toLowerCase();
+                            tag = tag.replaceAll(" ", "-");  // 半角スペース -> 半角ハイフン
+                            tag = tag.replaceAll("/", "");  // 半角スラッシュ -> 空文字
+                            return tag;
+                        }
                     });
                 }
             }

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/docs/AbstractDocsCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/docs/AbstractDocsCodegenConfig.java
@@ -285,7 +285,7 @@ public abstract class AbstractDocsCodegenConfig extends AbstractCodegenConfig {
     }
 
     private Object createEventDocument(final Swagger swagger, final Operation operation) {
-        DConnectOperation dConnectOperation = DConnectOperation.parse(swagger, operation);
+        DConnectOperation dConnectOperation = DConnectOperation.parse(operation);
         if (dConnectOperation == null) {
             return null;
         }

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/docs/HtmlDocsCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/docs/HtmlDocsCodegenConfig.java
@@ -7,24 +7,8 @@
 package org.deviceconnect.codegen.docs;
 
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
-import io.swagger.codegen.CodegenType;
-import io.swagger.codegen.DefaultCodegen;
 import io.swagger.codegen.SupportingFile;
-import io.swagger.models.*;
-import io.swagger.models.parameters.FormParameter;
-import io.swagger.models.parameters.Parameter;
-import io.swagger.models.parameters.QueryParameter;
-import io.swagger.models.properties.ArrayProperty;
-import io.swagger.models.properties.ObjectProperty;
-import io.swagger.models.properties.Property;
-import io.swagger.models.properties.RefProperty;
-import org.deviceconnect.codegen.DConnectCodegenConfig;
-import org.deviceconnect.codegen.models.DConnectOperation;
+import io.swagger.models.Swagger;
 
 import java.util.*;
 

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/models/DConnectOperation.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/models/DConnectOperation.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.models.Operation;
 import io.swagger.models.Response;
-import io.swagger.models.Swagger;
 import io.swagger.models.parameters.Parameter;
 import io.swagger.models.properties.RefProperty;
 

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/plugin/AbstractPluginCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/plugin/AbstractPluginCodegenConfig.java
@@ -114,7 +114,7 @@ public abstract class AbstractPluginCodegenConfig extends AbstractCodegenConfig 
 
             for (Map.Entry<HttpMethod, Operation> operationEntry : path.getOperationMap().entrySet()) {
                 HttpMethod method = operationEntry.getKey();
-                DConnectOperation operation = DConnectOperation.parse(swagger, operationEntry.getValue());
+                DConnectOperation operation = DConnectOperation.parse(operationEntry.getValue());
 
                 final Map<String, Object> api = new HashMap<>();
                 final String interfaceName = dConnectPath.getInterfaceName();

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/plugin/AndroidPluginCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/plugin/AndroidPluginCodegenConfig.java
@@ -207,38 +207,6 @@ public class AndroidPluginCodegenConfig extends AbstractPluginCodegenConfig {
     }
 
     @Override
-    public String toModelName(String name) {
-        // add prefix, suffix if needed
-        if (!StringUtils.isEmpty(modelNamePrefix)) {
-            name = modelNamePrefix + "_" + name;
-        }
-
-        if (!StringUtils.isEmpty(modelNameSuffix)) {
-            name = name + "_" + modelNameSuffix;
-        }
-
-        // camelize the model name
-        // phone_number => PhoneNumber
-        name = camelize(sanitizeName(name));
-
-        // model name cannot use reserved keyword, e.g. return
-        if (isReservedWord(name)) {
-            String modelName = "Model" + name;
-            LOGGER.warn(name + " (reserved word) cannot be used as model name. Renamed to " + modelName);
-            return modelName;
-        }
-
-        // model name starts with number
-        if (name.matches("^\\d.*")) {
-            String modelName = "Model" + name; // e.g. 200Response => Model200Response (after camelize)
-            LOGGER.warn(name + " (model name starts with number) cannot be used as model name. Renamed to " + modelName);
-            return modelName;
-        }
-
-        return name;
-    }
-
-    @Override
     public String toParamName(String name) {
         // should be the same as variable name
         return toVarName(name);

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/server/EmulatorCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/server/EmulatorCodegenConfig.java
@@ -26,6 +26,7 @@ import org.apache.commons.cli.CommandLine;
 import org.deviceconnect.codegen.AbstractCodegenConfig;
 import org.deviceconnect.codegen.DConnectCodegenConfig;
 import org.deviceconnect.codegen.ValidationResultSet;
+import org.deviceconnect.codegen.models.DConnectOperation;
 
 import java.io.File;
 import java.io.IOException;
@@ -276,17 +277,20 @@ public class EmulatorCodegenConfig extends AbstractCodegenConfig implements DCon
                         if (method == HttpMethod.PUT) {
                             try {
                                 Operation operation = operationMap.get(method);
-                                JsonNode event = (JsonNode) operation.getVendorExtensions().get("x-event");
-                                if (event != null) {
-                                    JsonNode examples = event.get("examples");
-                                    if (examples != null) {
-                                        JsonNode json = examples.get("application/json");
-                                        if (json != null) {
-                                            final String eventJson = mapper.writeValueAsString(json);
-                                            eventList.add(new Object() {
-                                                String key = (basePath + pathname).toLowerCase();
-                                                String json = eventJson;
-                                            });
+                                DConnectOperation dConnectOperation = DConnectOperation.parse(operation);
+                                if (dConnectOperation != null) {
+                                    Response event = dConnectOperation.getEventModel();
+                                    if (event != null) {
+                                        Map<String, Object> examples = event.getExamples();
+                                        if (examples != null) {
+                                            Object json = examples.get("application/json");
+                                            if (json != null) {
+                                                final String eventJson = mapper.writeValueAsString(json);
+                                                eventList.add(new Object() {
+                                                    String key = (basePath + pathname).toLowerCase();
+                                                    String json = eventJson;
+                                                });
+                                            }
                                         }
                                     }
                                 }

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/server/EmulatorCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/server/EmulatorCodegenConfig.java
@@ -24,7 +24,6 @@ import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.parser.SwaggerParser;
-import io.swagger.util.Json;
 import io.swagger.util.Yaml;
 import org.apache.commons.cli.CommandLine;
 import org.deviceconnect.codegen.*;

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/server/EmulatorCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/server/EmulatorCodegenConfig.java
@@ -15,16 +15,15 @@ import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-import com.sun.org.apache.xml.internal.utils.Hashtree2Node;
 import io.swagger.codegen.*;
 import io.swagger.models.*;
 import io.swagger.parser.SwaggerParser;
 import io.swagger.util.Yaml;
 import org.apache.commons.cli.CommandLine;
+import org.deviceconnect.codegen.AbstractCodegenConfig;
 import org.deviceconnect.codegen.DConnectCodegenConfig;
 import org.deviceconnect.codegen.ValidationResultSet;
 
@@ -40,7 +39,7 @@ import java.util.*;
  * This class is implemented by modification of NodeJSServerCodegen class.
  * </p>
  */
-public class EmulatorCodegenConfig extends DefaultCodegen implements DConnectCodegenConfig {
+public class EmulatorCodegenConfig extends AbstractCodegenConfig implements DConnectCodegenConfig {
 
     private Map<String, Swagger> profileSpecs;
 
@@ -48,6 +47,10 @@ public class EmulatorCodegenConfig extends DefaultCodegen implements DConnectCod
     protected int serverPort = 4035;
     protected String projectName = "swagger-server";
 
+    @Override
+    protected String profileFileFolder() {
+        return null; // Not be used.
+    }
 
     public EmulatorCodegenConfig() {
         super();
@@ -241,7 +244,7 @@ public class EmulatorCodegenConfig extends DefaultCodegen implements DConnectCod
 
     private void checkPaths(final Swagger swagger) {
         List<Object> pathList = new ArrayList<>();
-        final String basePath = swagger.getBasePath();
+       final String basePath = swagger.getBasePath();
         Map<String, Path> paths = swagger.getPaths();
         if (paths != null) {
             for (final Iterator<String> it = paths.keySet().iterator(); it.hasNext(); ) {
@@ -408,7 +411,7 @@ public class EmulatorCodegenConfig extends DefaultCodegen implements DConnectCod
 
     @Override
     public Map<String, Object> postProcessSupportingFileData(Map<String, Object> objs) {
-        Swagger swagger = (Swagger)objs.get("swagger");
+        Swagger swagger = getOriginalSwagger();
         if(swagger != null) {
             try {
                 SimpleModule module = new SimpleModule();

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/server/EmulatorCodegenConfig.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/server/EmulatorCodegenConfig.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import io.swagger.codegen.*;
 import io.swagger.models.*;
+import io.swagger.models.properties.ObjectProperty;
 import io.swagger.models.properties.Property;
 import io.swagger.models.properties.RefProperty;
 import io.swagger.parser.SwaggerParser;
@@ -522,8 +523,14 @@ public class EmulatorCodegenConfig extends AbstractCodegenConfig implements DCon
             if (!jsonPointers.contains(jsonPointer)) {
                 jsonPointers.add(jsonPointer);
             }
-        } else {
-            // TODO オブジェクトプロパティもトレースする.
+        } else if (property instanceof ObjectProperty) {
+            ObjectProperty object = (ObjectProperty) property;
+            Map<String, Property> properties = object.getProperties();
+            if (properties != null) {
+                for (Map.Entry<String, Property> entry : properties.entrySet()) {
+                    collectReferencesFromProperty(entry.getValue(), jsonPointers);
+                }
+            }
         }
     }
 
@@ -541,8 +548,13 @@ public class EmulatorCodegenConfig extends AbstractCodegenConfig implements DCon
             if (!jsonPointers.contains(jsonPointer)) {
                 jsonPointers.add(jsonPointer);
             }
-        } else {
-            // TODO オブジェクトプロパティもトレースする.
+        }
+
+        Map<String, Property> properties = model.getProperties();
+        if (properties != null) {
+            for (Map.Entry<String, Property> entry : properties.entrySet()) {
+                collectReferencesFromProperty(entry.getValue(), jsonPointers);
+            }
         }
     }
 

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/util/SortedSwagger.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/util/SortedSwagger.java
@@ -1,0 +1,32 @@
+/*
+ SortedSwagger.java
+ Copyright (c) 2018 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
+package org.deviceconnect.codegen.util;
+
+
+import io.swagger.models.Path;
+import io.swagger.models.Swagger;
+
+import java.util.*;
+
+public class SortedSwagger extends Swagger {
+
+    @Override
+    public Map<String, Path> getPaths() {
+        if (paths == null) {
+            return null;
+        }
+        Map<String, Path> sorted = new LinkedHashMap<String, Path>();
+        List<String> keys = new ArrayList<String>();
+        keys.addAll(paths.keySet());
+        Collections.sort(keys);
+
+        for (String key : keys) {
+            sorted.put(key, paths.get(key));
+        }
+        return sorted;
+    }
+}

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/util/SwaggerUtils.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/util/SwaggerUtils.java
@@ -1,3 +1,9 @@
+/*
+ SwaggerUtils.java
+ Copyright (c) 2018 NTT DOCOMO,INC.
+ Released under the MIT license
+ http://opensource.org/licenses/mit-license.php
+ */
 package org.deviceconnect.codegen.util;
 
 
@@ -20,7 +26,7 @@ public final class SwaggerUtils {
 
     public static Swagger cloneSwagger(final Swagger swagger) throws IOException {
         JsonNode json = convertToNode(swagger);
-        return Json.mapper().convertValue(json, Swagger.class);
+        return Json.mapper().convertValue(json, SortedSwagger.class);
     }
 
     private SwaggerUtils() {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/util/SwaggerUtils.java
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/java/org/deviceconnect/codegen/util/SwaggerUtils.java
@@ -1,0 +1,28 @@
+package org.deviceconnect.codegen.util;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.models.Swagger;
+import io.swagger.util.Json;
+
+import java.io.IOException;
+
+public final class SwaggerUtils {
+
+    private static JsonNode convertToNode(final Swagger swagger) throws IOException {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        String jsonAsString = mapper.writeValueAsString(swagger);
+        return mapper.readTree(jsonAsString);
+    }
+
+    public static Swagger cloneSwagger(final Swagger swagger) throws IOException {
+        JsonNode json = convertToNode(swagger);
+        return Json.mapper().convertValue(json, Swagger.class);
+    }
+
+    private SwaggerUtils() {
+    }
+}

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/authorization.json
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/authorization.json
@@ -12,6 +12,7 @@
                 "x-type": "one-shot",
                 "summary": "",
                 "description": "",
+                "operationId": "authorizationGrantGet",
                 "parameters": [],
                 "responses": {
                     "200": {
@@ -36,6 +37,7 @@
                 "x-type": "one-shot",
                 "summary": "",
                 "description": "",
+                "operationId": "authorizationAccessTokenGet",
                 "parameters": [
                     {
                         "name": "clientId",

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/authorization.json
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/authorization.json
@@ -6,6 +6,7 @@
         "description": ""
     },
     "consumes": [],
+    "basePath": "/gotapi/authorization",
     "paths": {
         "/grant": {
             "get": {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/availability.json
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/availability.json
@@ -13,6 +13,7 @@
                 "x-type": "one-shot",
                 "summary": "",
                 "description": "",
+                "operationId": "availabilityGet",
                 "parameters": [],
                 "responses": {
                     "200": {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/service.mustache
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/service.mustache
@@ -26,5 +26,3 @@ exports.{{nickname}} = function(args, res, next) {
 
 {{/operation}}
 {{/operations}}
-
-exports.service

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/servicediscovery.json
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/servicediscovery.json
@@ -13,6 +13,7 @@
                 "x-type": "one-shot",
                 "summary": "",
                 "description": "",
+                "operationId": "serviceDiscoveryGet",
                 "parameters": [],
                 "responses": {
                     "200": {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/serviceinformation.json
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/serviceinformation.json
@@ -6,6 +6,7 @@
         "description": ""
     },
     "consumes": [],
+    "basePath": "/gotapi/serviceInformation",
     "paths": {
         "/": {
             "get": {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/serviceinformation.json
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectEmulator/serviceinformation.json
@@ -12,6 +12,7 @@
                 "x-type": "one-shot",
                 "summary": "",
                 "description": "",
+                "operationId": "serviceInformationGet",
                 "parameters": [
                     {
                         "name": "serviceId",

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectHtmlApp/js/checker.js
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectHtmlApp/js/checker.js
@@ -270,6 +270,9 @@ var main = (function(parent, global) {
 
     function createDConnectPath(basePath, path) {
         if (basePath !== undefined) {
+        	if (basePath === '/') {
+                basePath = '';
+        	}
             return basePath + path;
         }
         if (path === '/') {

--- a/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectMarkdownDocs/profile.md.mustache
+++ b/DeviceConnectCodegen/modules/deviceconnect-codegen/src/main/resources/deviceConnectMarkdownDocs/profile.md.mustache
@@ -7,14 +7,14 @@
     <tbody>
         <tr><th>API</th><th>概要</th></tr>
         {{#operationList}}
-        <tr><td><a href="#{{id}}">{{name}}</a></td><td>{{{summary}}}</td></tr>
+        <tr><td><a href="#{{tag}}">{{name}}</a></td><td>{{{summary}}}</td></tr>
         {{/operationList}}
     </tbody>
 </table>
 
 {{#operationList}}
 
-## <a name="{{id}}">{{name}}</a>
+## <a id="{{tag}}">{{name}}</a>
 
 ### 種別
 {{type}}

--- a/DeviceConnectCodegen/pom.xml
+++ b/DeviceConnectCodegen/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.deviceconnect</groupId>
     <artifactId>deviceconnect-codegen-project</artifactId>
-    <version>1.8.1</version>
+    <version>1.8.2</version>
 
     <packaging>pom</packaging>
 

--- a/DeviceConnectCodegen/samples/sample-profile-specs/swagger-files/deviceOrientation.json
+++ b/DeviceConnectCodegen/samples/sample-profile-specs/swagger-files/deviceOrientation.json
@@ -183,6 +183,33 @@
                 }
             ]
         },
+        "AccelerationInfo": {
+            "type": "object",
+            "title": "加速度",
+            "description": "加速度のオブジェクト。",
+            "required": [
+                "x",
+                "y",
+                "z"
+            ],
+            "properties": {
+                "x": {
+                    "type": "number",
+                    "title": "x軸成分",
+                    "description": "x軸方向への加速度（m/s2）。"
+                },
+                "y": {
+                    "type": "number",
+                    "title": "y軸成分",
+                    "description": "y軸方向への加速度（m/s2）。"
+                },
+                "z": {
+                    "type": "number",
+                    "title": "z軸成分",
+                    "description": "z軸方向への加速度（m/s2）。"
+                }
+            }
+        },
         "DeviceOrientationInfo": {
             "type": "object",
             "required": [
@@ -203,31 +230,7 @@
                             "description": "インターバル (単位: ミリ秒)"
                         },
                         "acceleration": {
-                            "type": "object",
-                            "title": "加速度",
-                            "description": "加速度のオブジェクト。",
-                            "required": [
-                                "x",
-                                "y",
-                                "z"
-                            ],
-                            "properties": {
-                                "x": {
-                                    "type": "number",
-                                    "title": "x軸成分",
-                                    "description": "x軸方向への加速度（m/s2）。"
-                                },
-                                "y": {
-                                    "type": "number",
-                                    "title": "y軸成分",
-                                    "description": "y軸方向への加速度（m/s2）。"
-                                },
-                                "z": {
-                                    "type": "number",
-                                    "title": "z軸成分",
-                                    "description": "z軸方向への加速度（m/s2）。"
-                                }
-                            }
+                            "$ref": "#/definitions/AccelerationInfo"
                         },
                         "accelerationIncludingGravity": {
                             "type": "object",

--- a/DeviceConnectCodegen/samples/sample-profile-specs/swagger-files/deviceOrientation.json
+++ b/DeviceConnectCodegen/samples/sample-profile-specs/swagger-files/deviceOrientation.json
@@ -183,33 +183,6 @@
                 }
             ]
         },
-        "AccelerationInfo": {
-            "type": "object",
-            "title": "加速度",
-            "description": "加速度のオブジェクト。",
-            "required": [
-                "x",
-                "y",
-                "z"
-            ],
-            "properties": {
-                "x": {
-                    "type": "number",
-                    "title": "x軸成分",
-                    "description": "x軸方向への加速度（m/s2）。"
-                },
-                "y": {
-                    "type": "number",
-                    "title": "y軸成分",
-                    "description": "y軸方向への加速度（m/s2）。"
-                },
-                "z": {
-                    "type": "number",
-                    "title": "z軸成分",
-                    "description": "z軸方向への加速度（m/s2）。"
-                }
-            }
-        },
         "DeviceOrientationInfo": {
             "type": "object",
             "required": [
@@ -230,7 +203,31 @@
                             "description": "インターバル (単位: ミリ秒)"
                         },
                         "acceleration": {
-                            "$ref": "#/definitions/AccelerationInfo"
+                            "type": "object",
+                            "title": "加速度",
+                            "description": "加速度のオブジェクト。",
+                            "required": [
+                                "x",
+                                "y",
+                                "z"
+                            ],
+                            "properties": {
+                                "x": {
+                                    "type": "number",
+                                    "title": "x軸成分",
+                                    "description": "x軸方向への加速度（m/s2）。"
+                                },
+                                "y": {
+                                    "type": "number",
+                                    "title": "y軸成分",
+                                    "description": "y軸方向への加速度（m/s2）。"
+                                },
+                                "z": {
+                                    "type": "number",
+                                    "title": "z軸成分",
+                                    "description": "z軸方向への加速度（m/s2）。"
+                                }
+                            }
                         },
                         "accelerationIncludingGravity": {
                             "type": "object",


### PR DESCRIPTION
# 改修内容
- [共通] swagger-codegen v2.2.3 を使用するように変更。v2.2.1 に関する脆弱性への対処のため。
- [Markdown] 不具合修正: GitHub Wikiにアップロードすると各API仕様へのタグジャンプが行えない。